### PR TITLE
Updated for recent version of R and perl

### DIFF
--- a/R/TranslocDedup.R
+++ b/R/TranslocDedup.R
@@ -21,7 +21,7 @@ parser <- arg_parser("mark duplicate juntions",
                  type="integer") %>%
     add_argument("--barcode",
                  "",
-                 default=NA,
+                 default=0,
                  type="integer") %>%
     add_argument("--cores",
                  "",

--- a/lib/TranslocFilters.pl
+++ b/lib/TranslocFilters.pl
@@ -178,10 +178,10 @@ sub filter_mapqual ($) {
       my $min_AS_threshold = $tlx_R1_aln->{AS} + $tlx_R2_aln->{AS} - $min_difference;
 
       
-      foreach my $R1_aln_ID (keys $R1_alns) {
+      foreach my $R1_aln_ID (keys %$R1_alns) {
         next if $R1_aln_ID eq $tlx->{R1_ID};
 
-        foreach my $R2_aln_ID (keys $R2_alns) {
+        foreach my $R2_aln_ID (keys %$R2_alns) {
 
           my $R1_aln = $R1_alns->{$R1_aln_ID};
           my $R2_aln = $R2_alns->{$R2_aln_ID};
@@ -226,7 +226,7 @@ sub filter_mapqual ($) {
       my $min_AS_threshold = $tlx_R1_aln->{AS} - $min_difference;
 
       # only consider R1 alignments
-      foreach my $R1_aln_ID (keys $R1_alns) {
+      foreach my $R1_aln_ID (keys %$R1_alns) {
         next if $R1_aln_ID eq $tlx->{R1_ID};
 
         my $R1_aln = $R1_alns->{$R1_aln_ID};
@@ -263,7 +263,7 @@ sub filter_mapqual ($) {
       my $min_AS_threshold = $tlx_R2_aln->{AS} - $min_difference;
 
       # only consider R2 alignments
-      foreach my $R2_aln_ID (keys $R2_alns) {
+      foreach my $R2_aln_ID (keys %$R2_alns) {
         next if $R2_aln_ID eq $tlx->{R2_ID};
 
         my $R2_aln = $R2_alns->{$R2_aln_ID};

--- a/lib/TranslocHelper.pl
+++ b/lib/TranslocHelper.pl
@@ -106,8 +106,8 @@ sub find_optimal_coverage_set ($$) {
   my @graph = ();
   my $OCS_ptr;
 
-  my @R1_alns = sort {$a->{Qstart} <=> $b->{Qstart}} shuffle(values $R1_alns_ref);
-  my @R2_alns = sort {$a->{Qstart} <=> $b->{Qstart}} shuffle(values $R2_alns_ref);
+  my @R1_alns = sort {$a->{Qstart} <=> $b->{Qstart}} shuffle(ref($R1_alns_ref) eq 'ARRAY' ? @$R1_alns_ref : values %$R1_alns_ref);
+  my @R2_alns = sort {$a->{Qstart} <=> $b->{Qstart}} shuffle(ref($R2_alns_ref) eq 'ARRAY' ? @$R2_alns_ref : values %$R2_alns_ref);
 
   my $qname = $R1_alns[0]->{QnameShort};
 


### PR DESCRIPTION
The following changes allowed the pipeline to be run using:

R: 3.4.4
Perl: 5.26.1

I do not know the implications for setting the default barcode to 0 for the de-duplication R script. The use of NA for the integer type is not allowed in this version of R. With this change the script ran and found some duplicates.

From perl 5.24 the `keys` and `values` keywords cannot accept a reference. The argument must be an array or a hash (see [perldoc: values](https://perldoc.perl.org/functions/values.html)).
